### PR TITLE
Firewall

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,3 +20,4 @@ suites:
   - name: default
     run_list:
       - recipe[rackspace_support::default]
+      - recipe[rackspace_support_test::_firewall]

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source "https://supermarket.chef.io"
 
+cookbook 'rackspace_support_test', path: 'test/fixtures/cookbooks/rackspace_support_test'
+
 metadata

--- a/recipes/_firewall.rb
+++ b/recipes/_firewall.rb
@@ -16,12 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-firewall 'iptables' do
-  action :enable
-  provider Chef::Provider::FirewallIptables
-end
-
 # Rackspace Bastion Access
 %w(
   72.3.128.84/32
@@ -67,22 +61,4 @@ end
     action :allow
     description 'Rackspace Support Access'
   end
-end
-
-firewall_rule 'open_loopback' do
-  provider Chef::Provider::FirewallRuleIptables
-  interface 'lo'
-  action :allow
-end
-
-firewall_rule 'allow_established' do
-  provider Chef::Provider::FirewallRuleIptables
-  stateful %w(RELATED ESTABLISHED)
-  description 'Allow Established'
-  action :allow
-end
-
-firewall_rule 'drop_not_allowed' do
-  provider Chef::Provider::FirewallRuleIptables
-  action :reject
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,10 +36,6 @@ if rackconnected?
   end
 end
 
-unless rackconnected? || node['rackspace_support']['ignore_firewall']
-  include_recipe 'rackspace_support::_firewall'
-end
-
 remoteip = node.deep_fetch('public_info', 'remote_ip')
 if remoteip =~ /[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/
   # Assign the external_ip tag to the node if node['public_info']['remote_ip'] looks like an IP.

--- a/test/fixtures/cookbooks/rackspace_support_test/README.md
+++ b/test/fixtures/cookbooks/rackspace_support_test/README.md
@@ -1,0 +1,1 @@
+This is a test fixture cookbook for the rackspace_support::_firewall recipe

--- a/test/fixtures/cookbooks/rackspace_support_test/metadata.rb
+++ b/test/fixtures/cookbooks/rackspace_support_test/metadata.rb
@@ -1,0 +1,4 @@
+name 'rackspace_support_test'
+version '0.0.1'
+
+depends 'rackspace_support'

--- a/test/fixtures/cookbooks/rackspace_support_test/recipes/_firewall.rb
+++ b/test/fixtures/cookbooks/rackspace_support_test/recipes/_firewall.rb
@@ -1,0 +1,8 @@
+#
+# rackspace_support::_firewall fixture test
+firewall 'iptables' do
+  action :enable
+  provider Chef::Provider::FirewallIptables
+end
+
+include_recipe 'rackspace_support::_firewall'

--- a/test/integration/default/serverspec/_firewall_spec.rb
+++ b/test/integration/default/serverspec/_firewall_spec.rb
@@ -1,0 +1,42 @@
+# Encoding: utf-8
+
+require 'spec_helper'
+
+# Rackspace Bastion Access
+%w(
+  72.3.128.84/32
+  69.20.0.1/32
+  50.57.22.125/32
+  120.136.34.22/32
+  212.100.225.49/32
+  212.100.225.42/32
+  119.9.4.2/32
+).each do |bast_range|
+  describe iptables do
+    it { should have_rule("-A INPUT -s #{bast_range} -p tcp -m tcp -m comment --comment \"Bastion Access\" -j ACCEPT") }
+  end
+end
+
+# Rackspace Cloud Monitoring Access
+%w(
+  50.56.142.128/26
+  50.57.61.0/26
+  78.136.44.0/26
+  180.150.149.64/26
+  69.20.52.192/26
+  92.52.126.0/24
+).each do |cmon_range|
+  describe iptables do
+    it { should have_rule("-A INPUT -s #{cmon_range} -p tcp -m tcp -m comment --comment \"Cloud Monitoring Access\" -j ACCEPT") }
+  end
+end
+
+# Rackspace Support Access
+%w(
+  50.56.230.0/24
+  50.56.228.0/24
+).each do |sup_range|
+  describe iptables do
+    it { should have_rule("-A INPUT -s #{sup_range} -p tcp -m tcp -m comment --comment \"Rackspace Support Access\" -j ACCEPT") }
+  end
+end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,0 +1,6 @@
+# Encoding: utf-8
+require 'serverspec'
+
+set :backend, :exec
+
+set :path, '/sbin:/usr/local/sbin:/bin:/usr/bin:$PATH'


### PR DESCRIPTION
I essentially want to bake down the firewall recipe to just a set of rules that we can control from here for Bastion, Monitoring and Support access. A wrapper recipe can now be used that includes this one, and sets the precedence with logic.
- Removed specific firewall recipe parts for inclusion of customer base recipes
- Created serverspec testing which provides a wrapper cookbook fixture for proper testing
